### PR TITLE
Fix several issues related to yaml rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ documents you produce, and add a link back here if you want!
 + [Pınar Demetçi](https://pinardemetci.github.io/)
 + [Qian Ge](https://conan7882.github.io/)
 + [Renan Souza](https://renansouza.org/) ([code](https://github.com/renan-souza/cv))
++ [Songlin Jiang](https://hollowman6.github.io/resume/)
 + [Stefan Doerr](https://github.com/stefdoerr/cv)
 + [Steve T.K. Jan](https://stevetkjan.github.io/)
 + [Swaminathan Gurumurthy](https://swami1995.github.io/)

--- a/cv.yaml
+++ b/cv.yaml
@@ -62,7 +62,7 @@ education:
     dates: 2014 -- 2019 # May 19, 2019
     overallGPA: 0.00/0.00
     details:
-      - "Thesis: \\textit{\\href{https://github.com/bamos/thesis}{Differentiable Optimization-Based Modeling for Machine Learning}}"
+      - "Thesis: \\href{https://github.com/bamos/thesis}{\\textit{Differentiable Optimization-Based Modeling for Machine Learning}}"
       - "Advisor: \\href{http://zicokolter.com}{J. Zico Kolter}"
   - school: Virginia Tech
     location: Blacksburg, VA

--- a/generate.py
+++ b/generate.py
@@ -601,6 +601,7 @@ MARKDOWN_CONTEXT = RenderContext(
         (r'\.~', '. '),  # spaces
         (r'\\ ', ' '),  # spaces
         (r'\\&', '&'),  # unescape &
+        (r'\\_', '_'),  # unescape _
         (r'\\\$', '\$'),  # unescape $
         (r'\\%', '%'),  # unescape %
         (r'\\textbf{(.*)}', r'**\1**'),  # bold text

--- a/generate.py
+++ b/generate.py
@@ -604,10 +604,10 @@ MARKDOWN_CONTEXT = RenderContext(
         (r'\\_', '_'),  # unescape _
         (r'\\\$', '\$'),  # unescape $
         (r'\\%', '%'),  # unescape %
-        (r'\\textbf{(.*)}', r'**\1**'),  # bold text
-        (r'\{ *\\bf *(.*)\}', r'**\1**'),
-        (r'\\textit{(.*)}', r'*\1*'),  # italic text
-        (r'\{ *\\it *(.*)\}', r'*\1*'),
+        (r'\\textbf{(.*?)}', r'<b>\1</b>'),  # bold text
+        (r'\{ *\\bf *(.*?)\}', r'<b>\1</b>'),
+        (r'\\textit{(.*?)}', r'<i>\1</i>'),  # italic text
+        (r'\{ *\\it *(.*?)\}', r'<i>\1</i>'),
         (r'\\LaTeX', 'LaTeX'),  # \LaTeX to boring old LaTeX
         (r'\\TeX', 'TeX'),  # \TeX to boring old TeX
         (' --- ', '&nbsp;-&nbsp;'),  # em dash

--- a/generate.py
+++ b/generate.py
@@ -393,7 +393,7 @@ def truncate_to_k(num):
     return f"{num_k}k+"
 
 
-def add_repo_data(context, config):
+def add_repo_data(context, config, in_tex):
     repo_htmls = shelve.open('repo_htmls.shelf')
 
     total_stars = 0
@@ -404,7 +404,7 @@ def add_repo_data(context, config):
 
         short_name = re.search('.*github\.com/(.*)', item['repo_url'])[1]
         if 'name' not in item:
-            item['name'] = short_name
+            item['name'] = short_name.replace('_', '\\_') if in_tex else short_name
 
         # Scrape the repo HTML instead of using the GitHub API
         # to avoid being rate-limited (sorry), and be nice by
@@ -517,7 +517,7 @@ class RenderContext(object):
                 section_template_name = os.path.join(self.SECTIONS_DIR, 'news.md')
                 section_data['items'] = section_content
             elif section_tag == 'repos':
-                total_stars = add_repo_data(self, section_content)
+                total_stars = add_repo_data(self, section_content, self._file_ending == '.tex')
                 section_data['items'] = section_content
                 section_data['total_stars'] = total_stars
                 section_template_name = os.path.join(


### PR DESCRIPTION
- Fix displaying GitHub repo name that contains `_`
  The GitHub repository name can contain ASCII letters, digits, and the characters ., -, and `_`.
  `_` has special meanings in LaTex and should be escaped if we want to display the repository name properly without causing the LaTex compilation to fail.
  repo e.g. https://github.com/VowpalWabbit/vowpal_wabbit
- Recognize escaped `_` when rendering from yaml to markdown
- Use lazy quantifiers & html tags in RE for bold/italic text when rendering from yaml into markdown
  e.g. Fix rendering:
  - \textbf{A}, \textbf{B}, \textbf{C}
  - \href{https://github.com}{\textit{D}}
- Add the link to my CV that uses the code here